### PR TITLE
Add unit test for repairing wheel with multiple top-level extensions

### DIFF
--- a/tests/multiple_top_level/MANIFEST.in
+++ b/tests/multiple_top_level/MANIFEST.in
@@ -1,0 +1,2 @@
+include pyproject.toml
+graft lib

--- a/tests/multiple_top_level/Makefile
+++ b/tests/multiple_top_level/Makefile
@@ -1,0 +1,9 @@
+all: lib/b/libb.so lib/a/liba.so
+
+
+lib/b/libb.so: lib/b/b.c
+	gcc -fPIC -shared -o lib/b/libb.so lib/b/b.c
+
+
+lib/a/liba.so: lib/b/libb.so lib/a/a.c
+	gcc -fPIC -shared -o lib/a/liba.so -Ilib/b -Llib/b -lb lib/a/a.c

--- a/tests/multiple_top_level/pyproject.toml
+++ b/tests/multiple_top_level/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["cython", "setuptools", "wheel"]

--- a/tests/multiple_top_level/setup.cfg
+++ b/tests/multiple_top_level/setup.cfg
@@ -1,0 +1,2 @@
+[build_ext]
+cython_c_in_temp = 1

--- a/tests/multiple_top_level/setup.py
+++ b/tests/multiple_top_level/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup, Extension, find_packages
+
+
+setup(
+    name='multiple_top_level',
+    version='1.0',
+    description='Auditwheel multiple top-level extensions example',
+    packages=find_packages(where='src'),
+    ext_modules=[
+        Extension(
+            'example_a',
+            ['src/example_a.pyx'],
+            include_dirs=['lib/a'],
+            library_dirs=['lib/a', 'lib/b'],
+            libraries=['a'],
+        ),
+        Extension(
+            'example_b',
+            ['src/example_b.pyx'],
+            include_dirs=['lib/a'],
+            library_dirs=['lib/a', 'lib/b'],
+            libraries=['a'],
+        ),
+    ],
+)

--- a/tests/multiple_top_level/src/example_a.pyx
+++ b/tests/multiple_top_level/src/example_a.pyx
@@ -1,0 +1,6 @@
+cdef extern from "a.h":
+    int fa();
+
+
+cpdef int example_a():
+    return fa()

--- a/tests/multiple_top_level/src/example_b.pyx
+++ b/tests/multiple_top_level/src/example_b.pyx
@@ -1,0 +1,6 @@
+cdef extern from "a.h":
+    int fa();
+
+
+cpdef int example_b():
+    return fa() * 10

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -3,8 +3,10 @@ import pytest
 import os
 import os.path as op
 import tempfile
+import re
 import shutil
 import warnings
+import zipfile
 from distutils.spawn import find_executable
 
 VERBOSE = True
@@ -196,3 +198,92 @@ def test_build_wheel_with_binary_executable(docker_container):
     output = docker_exec(
         python_id, 'python -c "from testpackage import runit; print(runit(1.5))"').strip()
     assert output.strip() == '2.25'
+
+
+def test_build_repair_multiple_top_level_modules_wheel(docker_container):
+    policy, manylinux_id, python_id, io_folder = docker_container
+    docker_exec(
+        manylinux_id,
+        [
+            'bash',
+            '-c',
+            'cd /auditwheel_src/tests/multiple_top_level '
+            '&& make '
+            '&& pip wheel . -w /io',
+        ],
+    )
+
+    filenames = os.listdir(io_folder)
+    assert filenames == ['multiple_top_level-1.0-cp35-cp35m-linux_x86_64.whl']
+    orig_wheel = filenames[0]
+    assert 'manylinux' not in orig_wheel
+
+    # Repair the wheel using the appropriate manylinux container
+    repair_command = (
+        'auditwheel repair --plat {policy}_x86_64 -w /io /io/{orig_wheel}'
+    ).format(policy=policy, orig_wheel=orig_wheel)
+    docker_exec(
+        manylinux_id,
+        [
+            'bash',
+            '-c',
+            (
+                'LD_LIBRARY_PATH='
+                '/auditwheel_src/tests/multiple_top_level/lib/a:'
+                '/auditwheel_src/tests/multiple_top_level/lib/b '
+            )
+            + repair_command,
+        ],
+    )
+    filenames = os.listdir(io_folder)
+
+    if policy == 'manylinux1':
+        expected_files = 2
+    elif policy == 'manylinux2010':
+        expected_files = 3  # We end up repairing the wheel twice to manylinux1
+
+    assert len(filenames) == expected_files
+
+    repaired_wheels = [fn for fn in filenames if policy in fn]
+    # Wheel picks up newer symbols when built in manylinux2010
+    expected_wheel_name = (
+        'multiple_top_level-1.0-cp35-cp35m-{}_x86_64.whl'
+    ).format(policy)
+    assert repaired_wheels == [expected_wheel_name]
+    repaired_wheel = repaired_wheels[0]
+    output = docker_exec(manylinux_id, 'auditwheel show /io/' + repaired_wheel)
+    assert (
+        '{wheel} is consistent'
+        ' with the following platform tag: "manylinux1_x86_64"'
+    ).format(wheel=repaired_wheel) in output.replace('\n', ' ')
+
+    # TODO: Remove once pip supports manylinux2010
+    docker_exec(
+        python_id,
+        "pip install git+https://github.com/wtolson/pip.git@manylinux2010",
+    )
+
+    docker_exec(python_id, 'pip install /io/' + repaired_wheel)
+    for mod, func, expected in [
+        ('example_a', 'example_a', '11'),
+        ('example_b', 'example_b', '110'),
+    ]:
+        output = docker_exec(
+            python_id,
+            [
+                'python',
+                '-c',
+                'from {mod} import {func}; print({func}())'.format(
+                    mod=mod, func=func
+                ),
+            ],
+        ).strip()
+        assert output.strip() == expected
+    with zipfile.ZipFile(os.path.join(io_folder, repaired_wheel)) as w:
+        for lib_name in ['liba', 'libb']:
+            assert any(
+                re.match(
+                    r'multiple_top_level.libs/{}.*\.so'.format(lib_name), name
+                )
+                for name in w.namelist()
+            )

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -245,7 +245,6 @@ def test_build_repair_multiple_top_level_modules_wheel(docker_container):
     assert len(filenames) == expected_files
 
     repaired_wheels = [fn for fn in filenames if policy in fn]
-    # Wheel picks up newer symbols when built in manylinux2010
     expected_wheel_name = (
         'multiple_top_level-1.0-cp35-cp35m-{}_x86_64.whl'
     ).format(policy)


### PR DESCRIPTION
Here I added unit test to build and test wheel with multiple top-level extensions which was requested at original pull request https://github.com/pypa/auditwheel/pull/90.

Should note that it will fail at your branch but pass at pypa master because of changes related to manylinux2010 policy, for example ``docker_container`` tuple now consists of 4 elements instead of 3 - ``policy`` field was added.