### PR TITLE
Set proper LD_LIBRARY_PATH for test

### DIFF
--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -292,8 +292,8 @@ def test_build_repair_multiple_top_level_modules_wheel(docker_container):
             '-c',
             (
                 'LD_LIBRARY_PATH='
-                '/auditwheel_src/tests/multiple_top_level/lib/a:'
-                '/auditwheel_src/tests/multiple_top_level/lib/b '
+                '/auditwheel_src/tests/multiple_top_level/lib-src/a:'
+                '/auditwheel_src/tests/multiple_top_level/lib-src/b '
             )
             + repair_command,
         ],


### PR DESCRIPTION
I'm really sorry for bothering you but it the last pull request I forgot to update LD_LIBRARY_PATH where auditwheel shout find libraries for test wheel.